### PR TITLE
Fixed the Browserify example in the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The value of params.name will be 'joe', not 'chris'.
 This library is [CommonJS](http://www.commonjs.org/) compatible, so you can use it in this way:
 
 ```javascript
-var Rlite = require('rlite'),
+var Rlite = require('rlite-router'),
 routes = new Rlite();
 
 routes.add('', function () {


### PR DESCRIPTION
The name used in the "require" has to be the same included in the package.json.