### PR TITLE
Fix module.exports regression

### DIFF
--- a/rlite.js
+++ b/rlite.js
@@ -69,8 +69,7 @@ function Rlite() {
 }
 
 (function (root, factory) {
-  var define = root.define,
-      module = root.module;
+  var define = root.define;
 
   if (define && define.amd) {
     define([], factory);


### PR DESCRIPTION
`module`, at least in a node env, doesn't really live inside the current scope as a property, so, with the current implementation, this happens:

```
hmh $ mkdir test-rl
hmh $ cd test-rl
test-rl $ npm i rlite-router
rlite-router@1.0.0 node_modules/rlite-router
test-rl $ node
> require('rlite-router')
{}
```

This PR fixes it.