### PR TITLE
Fix uncaught TypeError when ctx.params is undefined

### DIFF
--- a/rlite.js
+++ b/rlite.js
@@ -35,7 +35,7 @@ function Rlite() {
   }
 
   function processQuery(url, ctx) {
-    if (url) {
+    if (url && ctx.params) {
       var hash = url.indexOf('#'),
           esc = url.indexOf('%') >= 0 ? decode : noop,
           query = (hash < 0 ? url : url.slice(0, hash)).split('&');


### PR DESCRIPTION
The lookup function passes `{}` to `processQuery`'s `ctx` parameter in the event that `processUrl` returned no registered routes for the given URL (line 56). When this happens, the line `ctx.params[nameValue[0]] = esc(nameValue[1]);` throws a TypeError because the empty object `{}` has no `params` property (line 46).

The `processQuery` function is currently only used by the `lookup` function, and the `ctx.params` that `processQuery` sets are only ever used by `run` if a matching rule and callback are found (lines 83-86). Thus, it would be a waste of processing power to process the query if `ctx.params` is undefined, as `ctx.params` being undefined means that no rules were matched because of how `lookup` calls `processQuery`. Therefore the easiest way to correct this problem and avoid parsing the query unnecessarily is to modify `processQuery` such that it does not parse the query data if `ctx.params` is undefined.