### PR TITLE
Expose lookup

### DIFF
--- a/rlite.js
+++ b/rlite.js
@@ -75,6 +75,8 @@ function Rlite() {
     exists: function (url) {
       return !!lookup(url).cb;
     },
+    
+    lookup: lookup,
 
     run: function(url) {
       var result = lookup(url);


### PR DESCRIPTION
Hi, I recently came across another usage of the router which is to have it parse routes and give you back the params it matched instead of having it run the callback itself. `lookup` needs to be exposed and that's what this PR is all about :). What do you think about it? Thanks, Darío