### PR TITLE
Fix define() call

### DIFF
--- a/rlite.js
+++ b/rlite.js
@@ -6,7 +6,7 @@
   var define = root.define;
 
   if (define && define.amd) {
-    define([], factory);
+    define('rlite', [], factory);
   } else if (typeof module !== 'undefined' && module.exports) {
     module.exports = factory();
   } else {


### PR DESCRIPTION
The lack of a module name breaks usage with [Almond.js](https://github.com/jrburke/almond). This fixes it.